### PR TITLE
ci: create basic circle-ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,5 +35,5 @@ workflows:
   version: 2
   build-workflow:
     jobs:
-      - build
-      - tests
+      - build-linux-go-1.12
+      - tests-linux-go-1.12


### PR DESCRIPTION
fix #25 

let me know what you need. currently, it runs two jobs:

- `go build ./...`
- `go test ./...`