### PR TITLE
Added fix for testing some fork subtests EIP150 and Frontier

### DIFF
--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -280,8 +280,9 @@ func (t *StateTest) runETHSubtest(subtest StateSubtest) error {
 
 	_, logs, _, _ = RunState(ruleSet, db, statedb, env, vmTx)
 
-	// Only tests that are < EIP158 are Homestead
-	deleteEmptyObjects := subtest.Fork != "Homestead"
+	// Only delete empty objects for forks which have not implemented EIP158/161
+	blockNum, _ := new(big.Int).SetString(t.Env.CurrentNumber, 0)
+	deleteEmptyObjects := ruleSet.IsAtlantis(blockNum)
 
 	// Commit block
 	statedb.CommitTo(db, deleteEmptyObjects)


### PR DESCRIPTION
For the existing tests, I hadn't run into these cases because there was no Frontier or EIP150 specific tests and when there was, they did not create empty objects that would be deleted with the previous logic. This solves that issue and for every folder in ethereum tests that I have checked, every fork's tests have passed except Byzantium (which is because State Trie clearing hasn't been implemented).

