### PR TITLE
Makefile fix with go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ lint: ## Run all the linters
 
 test: ## Run all the tests
 	echo 'mode: atomic' > coverage.txt && \
-	${GO_MOD} go list ./... | xargs -n1 -I{} sh -c 'go test -covermode=atomic -coverprofile=coverage.tmp {} && \
+	${GO_MOD} go list ./... | xargs -n1 -I{} sh -c '${GO_MOD} go test -covermode=atomic -coverprofile=coverage.tmp {} && \
 	tail -n +2 coverage.tmp >> coverage.txt' && \
 	rm coverage.tmp
 


### PR DESCRIPTION
I previously didn't test every makefile command inside of the $GOPATH but since go modules is by default off and the flag set at the start of the command didn't persist, it went back to non-modules interactions.