### PR TITLE
Receipt fixes and state trie clearing detail

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -138,7 +138,7 @@ func (v *BlockValidator) ValidateState(block, parent *types.Block, statedb *stat
 	}
 	// Validate the state root against the received state root and throw
 	// an error if they don't match.
-	if root := statedb.IntermediateRoot(false); header.Root != root {
+	if root := statedb.IntermediateRoot(v.config.IsAtlantis(header.Number)); header.Root != root {
 		return fmt.Errorf("invalid merkle root: header=%x computed=%x", header.Root, root)
 	}
 	return nil

--- a/core/chain_manager.go
+++ b/core/chain_manager.go
@@ -263,7 +263,7 @@ func makeHeader(config *ChainConfig, parent *types.Block, state *state.StateDB) 
 		time = new(big.Int).Add(parent.Time(), big.NewInt(10)) // block time is fixed at 10 seconds
 	}
 	return &types.Header{
-		Root:       state.IntermediateRoot(false),
+		Root:       state.IntermediateRoot(config.IsAtlantis(parent.Number())),
 		ParentHash: parent.Hash(),
 		Coinbase:   parent.Coinbase(),
 		Difficulty: CalcDifficulty(config, time.Uint64(), parent.Header()),

--- a/core/database_util_test.go
+++ b/core/database_util_test.go
@@ -28,6 +28,8 @@ import (
 
 	"crypto/ecdsa"
 	"encoding/binary"
+	"strings"
+
 	"github.com/eth-classic/go-ethereum/common"
 	"github.com/eth-classic/go-ethereum/core/types"
 	"github.com/eth-classic/go-ethereum/core/vm"
@@ -35,7 +37,6 @@ import (
 	"github.com/eth-classic/go-ethereum/crypto/sha3"
 	"github.com/eth-classic/go-ethereum/ethdb"
 	"github.com/eth-classic/go-ethereum/rlp"
-	"strings"
 )
 
 type diffTest struct {
@@ -647,7 +648,7 @@ func TestReceiptStorage(t *testing.T) {
 	db, _ := ethdb.NewMemDatabase()
 
 	receipt1 := &types.Receipt{
-		PostState:         []byte{0x01},
+		Status:            types.TxFailure,
 		CumulativeGasUsed: big.NewInt(1),
 		Logs: vm.Logs{
 			&vm.Log{Address: common.BytesToAddress([]byte{0x11})},
@@ -658,7 +659,7 @@ func TestReceiptStorage(t *testing.T) {
 		GasUsed:         big.NewInt(111111),
 	}
 	receipt2 := &types.Receipt{
-		PostState:         []byte{0x02},
+		PostState:         []byte{},
 		CumulativeGasUsed: big.NewInt(2),
 		Logs: vm.Logs{
 			&vm.Log{Address: common.BytesToAddress([]byte{0x22})},
@@ -706,7 +707,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 	db, _ := ethdb.NewMemDatabase()
 
 	receipt1 := &types.Receipt{
-		PostState:         []byte{0x01},
+		Status:            types.TxFailure,
 		CumulativeGasUsed: big.NewInt(1),
 		Logs: vm.Logs{
 			&vm.Log{Address: common.BytesToAddress([]byte{0x11})},
@@ -717,7 +718,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 		GasUsed:         big.NewInt(111111),
 	}
 	receipt2 := &types.Receipt{
-		PostState:         []byte{0x02},
+		PostState:         []byte{},
 		CumulativeGasUsed: big.NewInt(2),
 		Logs: vm.Logs{
 			&vm.Log{Address: common.BytesToAddress([]byte{0x22})},

--- a/core/multivm_processor.go
+++ b/core/multivm_processor.go
@@ -179,7 +179,7 @@ Loop:
 	usedGas := vm.UsedGas()
 	totalUsedGas.Add(totalUsedGas, usedGas)
 
-	receipt := types.NewReceipt(statedb.IntermediateRoot(false).Bytes(), totalUsedGas)
+	receipt := types.NewReceipt(statedb.IntermediateRoot(config.IsAtlantis(header.Number)).Bytes(), totalUsedGas)
 	receipt.TxHash = tx.Hash()
 	receipt.GasUsed = new(big.Int).Set(totalUsedGas)
 	if vm.Failed() {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -119,8 +119,15 @@ func ApplyTransaction(config *ChainConfig, bc *BlockChain, gp *GasPool, statedb 
 	}
 
 	// Update the state with pending changes
+	var root []byte
+	if config.IsAtlantis(header.Number) {
+		statedb.Finalise(true)
+	} else {
+		root = statedb.IntermediateRoot(config.IsAtlantis(header.Number)).Bytes()
+	}
+
 	usedGas.Add(usedGas, gas)
-	receipt := types.NewReceipt(statedb.IntermediateRoot(false).Bytes(), usedGas)
+	receipt := types.NewReceipt(root, usedGas)
 	receipt.TxHash = tx.Hash()
 	receipt.GasUsed = new(big.Int).Set(gas)
 	if MessageCreatesContract(tx) {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -556,7 +556,7 @@ func (self *worker) commitNewWork() {
 	if atomic.LoadInt32(&self.mining) == 1 {
 		// commit state root after all state transitions.
 		core.AccumulateRewards(work.config, work.state, header, uncles)
-		header.Root = work.state.IntermediateRoot(false)
+		header.Root = work.state.IntermediateRoot(self.config.IsAtlantis(header.Number))
 	}
 
 	// create the new block whose nonce will be mined.


### PR DESCRIPTION
Changes how the receipts are encoded and decoded to follow proper protocol of replacing intermediate state root with status encoding. Also performs state trie clearing at some appropriate points in a simulated system that was previously missed (see: `state.IntermediateRoot(config.IsAtlantis(parent.Number())` like changes).

Since previous receipts would have had status encoded and saved into the database, I have made the decoding backwards compatible:

```go
// DecodeRLP implements rlp.Decoder, and loads both consensus and implementation
// fields of a receipt from an RLP stream.
func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
	raw, err := s.Raw()
	if err != nil {
		return err
	}

	// Try decoding the receipt without Status first
	if err := decodeStoredReceiptRLP(r, raw); err == nil {
		return nil
	}

	return decodeOldStoredReceiptRLP(r, raw)
}
```

where decodeOldStoredReceiptRLP does not assume the ambiguous nature of PostStateOrStatus field of the Receipts and sets both fields specifically.


Also cleaned up the struct declaration for encoding/ decoding because encoding and decoding an untyped interface relying on positional variables and the confusing logic structure was very bad.


Edit: Resolves #55 