### PR TITLE
ci: prepare assets for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build-linux-go-1.12:
+  build-linux-go-1-12:
     working_directory: ~/go-ethereum
     docker:
       - image: circleci/golang:1.12
@@ -16,7 +16,7 @@ jobs:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-  tests-linux-go-1.12:
+  tests-linux-go-1-12:
     working_directory: ~/go-ethereum
     docker:
       - image: circleci/golang:1.12
@@ -32,7 +32,7 @@ jobs:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-  release-linux-go-1.12:
+  release-linux-go-1-12:
     working_directory: ~/go-ethereum
     docker:
       - image: circleci/golang:1.12
@@ -51,8 +51,10 @@ workflows:
   version: 2
   main:
     jobs:
-      - build-linux-go-1.12
-      - tests-linux-go-1.12
-          requires: build-linux-go-1.12
-      - release-linux-go-1.12
-          requires: build-linux-go-1.12
+      - build-linux-go-1-12
+      - tests-linux-go-1-12
+          requires:
+            - build-linux-go-1-12
+      - release-linux-go-1-12
+          requires:
+            - build-linux-go-1-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-  release-linux-go-1-12:
+  relse-linux-go-1-12:
     working_directory: ~/go-ethereum
     docker:
       - image: circleci/golang:1.12
@@ -49,12 +49,8 @@ jobs:
 
 workflows:
   version: 2
-  main:
+  release:
     jobs:
       - build-linux-go-1-12
       - tests-linux-go-1-12
-          requires:
-            - build-linux-go-1-12
-      - release-linux-go-1-12
-          requires:
-            - build-linux-go-1-12
+      - relse-linux-go-1-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,10 @@ jobs:
           keys:
             - go-mod-v4-{{ checksum "go.sum" }}
       - run:
-          name: Compile
+          name: Compile Binaries
           command: make build
       - run:
-          name: Release
+          name: Release Artifacts
           command: |
             sha256sum ./bin/abigen > ./bin/abigen.sha256
             sha256sum ./bin/bootnode > ./bin/bootnode.sha256
@@ -24,9 +24,9 @@ jobs:
             sha256sum ./bin/rlpdump > ./bin/rlpdump.sha256
             mkdir ./artifacts/
             VERSION=$(bin/geth version | grep -i version | head -n1 | awk '{print $2}')
-            cp ./bin ./geth-classic-{$VERSION}
+            cp -rv ./bin ./geth-classic-{$VERSION}
             tar -zcvf geth-classic-{$VERSION}.tar.gz geth-classic-{$VERSION}
-            cp ./geth-classic-{$VERSION}.tar.gz ./artifacts/
+            cp -v ./geth-classic-{$VERSION}.tar.gz ./artifacts/
             sha256sum ./artifacts/geth-classic-{$VERSION}.tar.gz > ./artifacts/geth-classic-{$VERSION}.sha256
       - store_artifacts:
           path: ~/go-ethereum/artifacts
@@ -44,7 +44,7 @@ jobs:
           keys:
             - go-mod-v4-{{ checksum "go.sum" }}
       - run:
-          name: Run tests
+          name: Run All Tests
           command: make test
       - save_cache:
           key: go-mod-v4-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,19 +15,23 @@ jobs:
       - run:
           name: Release Artifacts
           command: |
-            sha256sum ./bin/abigen > ./bin/abigen.sha256
-            sha256sum ./bin/bootnode > ./bin/bootnode.sha256
-            sha256sum ./bin/disasm > ./bin/disasm.sha256
-            sha256sum ./bin/ethtest > ./bin/ethtest.sha256
-            sha256sum ./bin/evm > ./bin/evm.sha256
-            sha256sum ./bin/geth > ./bin/geth.sha256
-            sha256sum ./bin/rlpdump > ./bin/rlpdump.sha256
+            pushd ./bin/
+            sha256sum ./abigen > ./abigen.sha256
+            sha256sum ./bootnode > ./bootnode.sha256
+            sha256sum ./disasm > ./disasm.sha256
+            sha256sum ./ethtest > ./ethtest.sha256
+            sha256sum ./evm > ./evm.sha256
+            sha256sum ./geth > ./geth.sha256
+            sha256sum ./rlpdump > ./rlpdump.sha256
+            popd
             mkdir ./artifacts/
             VERSION=$(bin/geth version | grep -i version | head -n1 | awk '{print $2}')
             cp -rv ./bin ./geth-classic-${VERSION}-linux
             tar -zcvf geth-classic-${VERSION}-linux.tar.gz geth-classic-${VERSION}-linux
             cp -v ./geth-classic-${VERSION}-linux.tar.gz ./artifacts/
-            sha256sum ./artifacts/geth-classic-${VERSION}-linux.tar.gz > ./artifacts/geth-classic-${VERSION}-linux.sha256
+            pushd ./artifacts
+            sha256sum ./geth-classic-${VERSION}-linux.tar.gz > ./geth-classic-${VERSION}-linux.sha256
+            popd
       - store_artifacts:
           path: ~/go-ethereum/artifacts
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,12 +49,12 @@ jobs:
 
 workflows:
   version: 2
-  build-workflow:
+  main:
     jobs:
       - build-linux-go-1.12
       - tests-linux-go-1.12
-  release-workflow:
-    jobs:
+          requires:
+            - build-linux-go-1.12
       - release-linux-go-1.12
-        requires:
-          - build-linux-go-1.12
+          requires:
+            - build-linux-go-1.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,21 @@ jobs:
       - run:
           name: Release
           command: |
-            sha256sum ./bin/*
-            ./bin/geth version
+            sha256sum ./bin/abigen > ./bin/abigen.sha256
+            sha256sum ./bin/bootnode > ./bin/bootnode.sha256
+            sha256sum ./bin/disasm > ./bin/disasm.sha256
+            sha256sum ./bin/ethtest > ./bin/ethtest.sha256
+            sha256sum ./bin/evm > ./bin/evm.sha256
+            sha256sum ./bin/geth > ./bin/geth.sha256
+            sha256sum ./bin/rlpdump > ./bin/rlpdump.sha256
+            mkdir ./artifacts/
+            VERSION=$(bin/geth version | grep -i version | head -n1 | awk '{print $2}')
+            cp ./bin ./geth-classic-{$VERSION}
+            tar -zcvf geth-classic-{$VERSION}.tar.gz geth-classic-{$VERSION}
+            cp ./geth-classic-{$VERSION}.tar.gz ./artifacts/
+            sha256sum ./artifacts/geth-classic-{$VERSION}.tar.gz > ./artifacts/geth-classic-{$VERSION}.sha256
+      - store_artifacts:
+          path: ~/go-ethereum/artifacts
       - save_cache:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,8 @@ jobs:
       - run:
           name: Release
           command: |
-            ls -lsha ./
-            ls -lsha ./bin/
-            ls -lsha ./artifacts/
-            ./geth version
+            sha256sum ./bin/*
             ./bin/geth version
-            ./artifacts/bin/geth version
       - save_cache:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build-linux-go-1-12:
+  build-linux-go-1.12:
     working_directory: ~/go-ethereum
     docker:
       - image: circleci/golang:1.12
@@ -12,11 +12,20 @@ jobs:
       - run:
           name: Compile
           command: make build
+      - run:
+          name: Release
+          command: |
+            ls -lsha ./
+            ls -lsha ./bin/
+            ls -lsha ./artifacts/
+            ./geth version
+            ./bin/geth version
+            ./artifacts/bin/geth version
       - save_cache:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-  tests-linux-go-1-12:
+  tests-linux-go-1.12:
     working_directory: ~/go-ethereum
     docker:
       - image: circleci/golang:1.12
@@ -32,25 +41,10 @@ jobs:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-  relse-linux-go-1-12:
-    working_directory: ~/go-ethereum
-    docker:
-      - image: circleci/golang:1.12
-    steps:
-      - attach_workspace:
-          at: ./artifacts
-      - run:
-          name: Check Version
-          command: |
-            ls -lsha ./
-            ls -lsha ./artifacts
-            bin/geth version
-            go get github.com/tcnksm/ghr
 
 workflows:
   version: 2
   release:
     jobs:
-      - build-linux-go-1-12
-      - tests-linux-go-1-12
-      - relse-linux-go-1-12
+      - tests-linux-go-1.12
+      - build-linux-go-1.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,10 @@ jobs:
             sha256sum ./bin/rlpdump > ./bin/rlpdump.sha256
             mkdir ./artifacts/
             VERSION=$(bin/geth version | grep -i version | head -n1 | awk '{print $2}')
-            cp -rv ./bin ./geth-classic-${VERSION}
-            tar -zcvf geth-classic-${VERSION}.tar.gz geth-classic-${VERSION}
-            cp -v ./geth-classic-${VERSION}.tar.gz ./artifacts/
-            sha256sum ./artifacts/geth-classic-${VERSION}.tar.gz > ./artifacts/geth-classic-${VERSION}.sha256
+            cp -rv ./bin ./geth-classic-${VERSION}-linux
+            tar -zcvf geth-classic-${VERSION}-linux.tar.gz geth-classic-${VERSION}-linux
+            cp -v ./geth-classic-${VERSION}-linux.tar.gz ./artifacts/
+            sha256sum ./artifacts/geth-classic-${VERSION}-linux.tar.gz > ./artifacts/geth-classic-${VERSION}-linux.sha256
       - store_artifacts:
           path: ~/go-ethereum/artifacts
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             - go-mod-v4-{{ checksum "go.sum" }}
       - run:
           name: Compile
-          command: go build ./...
+          command: make build
       - save_cache:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
@@ -27,11 +27,25 @@ jobs:
             - go-mod-v4-{{ checksum "go.sum" }}
       - run:
           name: Run tests
-          command: go test ./...
+          command: make test
       - save_cache:
           key: go-mod-v4-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
+  release-linux-go-1.12:
+    working_directory: ~/go-ethereum
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: Check Version
+          command: |
+            ls -lsha ./
+            ls -lsha ./artifacts
+            bin/geth version
+            go get github.com/tcnksm/ghr
 
 workflows:
   version: 2
@@ -39,3 +53,8 @@ workflows:
     jobs:
       - build-linux-go-1.12
       - tests-linux-go-1.12
+  release-workflow:
+    jobs:
+      - release-linux-go-1.12
+        requires:
+          - build-linux-go-1.12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,10 @@ jobs:
             sha256sum ./bin/rlpdump > ./bin/rlpdump.sha256
             mkdir ./artifacts/
             VERSION=$(bin/geth version | grep -i version | head -n1 | awk '{print $2}')
-            cp -rv ./bin ./geth-classic-{$VERSION}
-            tar -zcvf geth-classic-{$VERSION}.tar.gz geth-classic-{$VERSION}
-            cp -v ./geth-classic-{$VERSION}.tar.gz ./artifacts/
-            sha256sum ./artifacts/geth-classic-{$VERSION}.tar.gz > ./artifacts/geth-classic-{$VERSION}.sha256
+            cp -rv ./bin ./geth-classic-${VERSION}
+            tar -zcvf geth-classic-${VERSION}.tar.gz geth-classic-${VERSION}
+            cp -v ./geth-classic-${VERSION}.tar.gz ./artifacts/
+            sha256sum ./artifacts/geth-classic-${VERSION}.tar.gz > ./artifacts/geth-classic-${VERSION}.sha256
       - store_artifacts:
           path: ~/go-ethereum/artifacts
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,6 @@ workflows:
     jobs:
       - build-linux-go-1.12
       - tests-linux-go-1.12
-          requires:
-            - build-linux-go-1.12
+          requires: build-linux-go-1.12
       - release-linux-go-1.12
-          requires:
-            - build-linux-go-1.12
+          requires: build-linux-go-1.12


### PR DESCRIPTION
Creates artifacts on CircleCI we can use for releases: 

- `geth-classic-v6.0.1-16-g7f356f2-linux.tar.gz`
- `geth-classic-v6.0.1-16-g7f356f2-linux.sha256`