### PR TITLE
Tests/atlantis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/testData"]
 	path = tests/testData
-	url = https://github.com/ethereum/tests.git
+	url = https://github.com/multi-geth/tests.git

--- a/tests/difficulty_test.go
+++ b/tests/difficulty_test.go
@@ -27,9 +27,10 @@ func TestETHDifficulty(t *testing.T) {
 
 	supportedTests := map[string]bool{
 		// "difficulty.json":          true, // Testing ETH mainnet config
-		"difficultyFrontier.json":  true,
-		"difficultyHomestead.json": true,
-		"difficultyByzantium.json": true,
+		"difficultyFrontier.json":        true,
+		"difficultyHomestead.json":       true,
+		"difficultyByzantium.json":       true,
+		"difficultyClassicAtlantis.json": true,
 	}
 
 	// Loop through each file

--- a/tests/init.go
+++ b/tests/init.go
@@ -141,6 +141,12 @@ var Forks = map[string]RuleSet{
 		DiehardBlock:             big.NewInt(0),
 		AtlantisBlock:            big.NewInt(0),
 	},
+	"ClassicAtlantis": {
+		HomesteadBlock:           big.NewInt(0),
+		HomesteadGasRepriceBlock: big.NewInt(0),
+		DiehardBlock:             big.NewInt(0),
+		AtlantisBlock:            big.NewInt(0),
+	},
 }
 
 // ChainConfigs table used to map configs to difficulty test files
@@ -170,6 +176,23 @@ var ChainConfigs = map[string]core.ChainConfig{
 		},
 	},
 	"difficultyByzantium.json": {
+		Forks: []*core.Fork{
+			{
+				Name:  "Atlantis",
+				Block: big.NewInt(0),
+				Features: []*core.ForkFeature{
+					{
+						ID: "difficulty",
+						Options: core.ChainFeatureConfigOptions{
+							"type":   "atlantis",
+							"length": 3000000,
+						},
+					},
+				},
+			},
+		},
+	},
+	"difficultyClassicAtlantis.json": {
 		Forks: []*core.Fork{
 			{
 				Name:  "Atlantis",

--- a/tests/util.go
+++ b/tests/util.go
@@ -113,7 +113,7 @@ func insertAccount(state *state.StateDB, saddr string, account Account) {
 	state.SetCode(addr, common.Hex2Bytes(account.Code))
 	if i, err := strconv.ParseUint(account.Nonce, 0, 64); err != nil {
 		if account.Nonce == "" {
-			i = 0
+			state.SetNonce(addr, 0)
 		} else {
 			panic(err)
 		}

--- a/tests/util.go
+++ b/tests/util.go
@@ -112,7 +112,11 @@ func insertAccount(state *state.StateDB, saddr string, account Account) {
 	addr := common.HexToAddress(saddr)
 	state.SetCode(addr, common.Hex2Bytes(account.Code))
 	if i, err := strconv.ParseUint(account.Nonce, 0, 64); err != nil {
-		panic(err)
+		if account.Nonce == "" {
+			i = 0
+		} else {
+			panic(err)
+		}
 	} else {
 		state.SetNonce(addr, i)
 	}


### PR DESCRIPTION
This is an experimental changeset that at least templates what's needed to run tests beyond those included in the ETH Foundation-specific suite ethereum/tests (which is as a submodule in the repo as `tests/testData`). 

- Move submodule remote origin to multi-geth/tests. I've been using multi-geth to fill tests, and have pushed changes there. Relevant changes are currently held there at feature branch `feat/etc-atlantis`; the submodule's HEAD is moved to that as well. 
- Adds hardcoded test chain configs. Ideally we can in the future move to reading chain specs on a per test, or per test suite, basis, removing the need for these "you just have to know how to configure it" lookups and technical debt. The tests submodule here also includes an example `chainspecs/` dir that intends to make a suggestion toward this. 

And... the tests pass, btw :) This means that we're able to use existing Byzantium test suites to create Atlantis tests (b/c the tests generator is hacky and piggy-backs existing state pre, envs, and transitions), and use multi-geth to create test target values that classic geth agrees on. With a few modifications to Parity's test runner, we should be able to extend this idea there as well.
